### PR TITLE
Don't process images all at once

### DIFF
--- a/app/controllers/covers_controller.rb
+++ b/app/controllers/covers_controller.rb
@@ -3,6 +3,19 @@ class CoversController < ApplicationController
 
   before_action :password_required, only: [:index, :archive, :archive_all, :update_order]
 
+  def artwork
+    cover = Cover.find(params[:id])
+
+    redirect_to_admin unless cover.artwork.attached?
+
+    @artwork =
+      if cover.artwork.variable?
+        cover.artwork.variant(resize_to_limit: [1440,1440]).processed.url
+      else
+        rails_blob_path(cover.artwork, disposition: "inline")
+      end
+  end
+
   def new
     @cover = Cover.new
   end

--- a/app/views/covers/_list.html.erb
+++ b/app/views/covers/_list.html.erb
@@ -44,11 +44,9 @@
     <b>Artwork:</b>
     <%= link_to(
       cover.artwork.blob.filename.sanitized,
-      cover.artwork.variable? ?
-        cover.artwork.variant(resize_to_limit: [1440,1440]).processed.url :
-          rails_blob_path(cover.artwork, disposition: "inline"),
-      target: "_blank"
-    ) %><br />
+      artwork_cover_path(cover), target: "_blank"
+    ) %>
+    <br />
   <% end %>
 
   <% if cover.blurb.present? %>

--- a/app/views/covers/artwork.html.erb
+++ b/app/views/covers/artwork.html.erb
@@ -1,0 +1,1 @@
+<%= image_tag @artwork, class: "d-block w-100" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
       post :archive
       post :unarchive
       post :toggle_b_side
+
+      get :artwork
     end
     collection do
       post :archive_all


### PR DESCRIPTION
For now, let's only load `artwork.variant.processed.url`s if someone has
explicitly clicked a link to see the cover artwork. We can do this by
just using another controller action for now.
